### PR TITLE
Reorganize packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ before_install:
   - go get -t -v ./...
 
 script:
-    - go test -race -coverprofile=coverage.txt -covermode=atomic
+    - go test ./... -race -coverprofile=coverage.txt -covermode=atomic
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-    - "1.8.x"
     - "1.9.x"
     - "1.10.x"
     - "master"

--- a/README.md
+++ b/README.md
@@ -3,30 +3,4 @@
 
 Contains some implementations of simple data structures in Go.
 
-## Stack
-`gostu.Stack` represents a stack data structure.
-
-```go
-// initialize a new stack
-s := NewStack()
-
-// Push some values
-s.Push(23)
-s.Push("something else")
-s.Push(34)
-
-// Get top value
-v, _ := s.Top()
-// v => 34
-
-// Pop value
-v, _ := s.Pop()
-// v => 34
-// s.Top() => "something else"
-
-// check if stack is emoty
-s.IsEmpty()
-// => false
-```
-
-Please note that you can add any kind of values to the stack. This is a limitation of golang, where there are no "type classes" supported for data structures. 
+1. [Stack](https://github.com/gsingharoy/gostu/tree/master/stack) 

--- a/stack/README.md
+++ b/stack/README.md
@@ -1,0 +1,27 @@
+# Stack
+`Stack` represents a stack data structure.
+
+```go
+// initialize a new stack
+s := New()
+
+// Push some values
+s.Push(23)
+s.Push("something else")
+s.Push(34)
+
+// Get top value
+v, _ := s.Top()
+// v => 34
+
+// Pop value
+v, _ := s.Pop()
+// v => 34
+// s.Top() => "something else"
+
+// check if stack is emoty
+s.IsEmpty()
+// => false
+```
+
+Please note that you can add any kind of values to the stack. This is a limitation of golang, where there are no "type classes" supported for data structures.

--- a/stack/errors.go
+++ b/stack/errors.go
@@ -1,4 +1,4 @@
-package gostu
+package stack
 
 import "errors"
 

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -1,26 +1,26 @@
-package gostu
+package stack
 
 // Simple Stack data structure
 // This is a unidirectional simple data structure
 // read here to know more about stacks : https://www.geeksforgeeks.org/stack-data-structure/
 type Stack struct {
-	top *stackField
+	top *node
 }
 
-type stackField struct {
+type node struct {
 	value interface{}
-	next  *stackField
+	next  *node
 }
 
 // NewStack() returns a pointer to a newly created empty Stack instance
-func NewStack() *Stack {
+func New() *Stack {
 	return &Stack{}
 }
 
 // Push(v interface{}) returns an error value
 // This method 'pushed' a value to the stack
 func (s *Stack) Push(v interface{}) error {
-	newField := &stackField{value: v, next: s.top}
+	newField := &node{value: v, next: s.top}
 	s.top = newField
 	return nil
 }

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -1,11 +1,11 @@
-package gostu
+package stack
 
 import (
 	"testing"
 )
 
 func TestNewStack(t *testing.T) {
-	s := NewStack()
+	s := New()
 	if s.top != nil {
 		t.Error("Expected top to be initialized to a null pointer")
 	}
@@ -13,7 +13,7 @@ func TestNewStack(t *testing.T) {
 
 func TestStackPush(t *testing.T) {
 	t.Log("adding to an empty stack")
-	s := NewStack()
+	s := New()
 	err1 := s.Push(45)
 	if err1 != nil {
 		t.Error("expected no error")
@@ -43,7 +43,7 @@ func TestStackPush(t *testing.T) {
 
 func TestStackPop(t *testing.T) {
 	t.Log("popping from an empty stack")
-	s := NewStack()
+	s := New()
 	_, err := s.Pop()
 	if err != ErrEmptyStack {
 		t.Error("expected error")
@@ -70,7 +70,7 @@ func TestStackPop(t *testing.T) {
 func TestStackIsEmpty(t *testing.T) {
 	t.Log("when stack is empty")
 
-	s := NewStack()
+	s := New()
 	if !s.IsEmpty() {
 		t.Error("expected stack to be empty")
 	}
@@ -85,7 +85,7 @@ func TestStackIsEmpty(t *testing.T) {
 func TestStackTop(t *testing.T) {
 	t.Log("when stack is empty")
 
-	s := NewStack()
+	s := New()
 
 	_, err := s.Top()
 	if err != ErrEmptyStack {

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestNewStack(t *testing.T) {
+func TestNew(t *testing.T) {
 	s := New()
 	if s.top != nil {
 		t.Error("Expected top to be initialized to a null pointer")
@@ -90,5 +90,19 @@ func TestStackTop(t *testing.T) {
 	_, err := s.Top()
 	if err != ErrEmptyStack {
 		t.Error("expected ErrEmptyStack to be returned")
+	}
+
+	s.Push(34)
+
+	v1, _ := s.Top()
+	if v1 != 34 {
+		t.Error("Expected the top node value")
+	}
+
+	s.Push(35)
+	s.Push(78)
+	v2, _ := s.Top()
+	if v2 != 78 {
+		t.Error("Expected the top node value")
 	}
 }


### PR DESCRIPTION
In order to avoid long redundant names for structs and functions, each data structure will have its own package.
With this a package, `stack`, has been introduced.